### PR TITLE
feat(HoC): merge className and class props to deal with things like styled-components

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,11 +65,16 @@ type HookProps<P> = PropType<P> & {
 
 type ChildHookProps<P> = PropsWithChildren<HookProps<P>>
 
+function genClassList (className?: string, classProp?: string): string {
+  return [className, classProp].filter(Boolean).join(' ')
+}
+
 export function withWebComponent<T extends HTMLElement, P = {}> (Component: ElementType<any>): ForwardRefExoticComponent<PropsWithoutRef<HookProps<P>> & RefAttributes<T>> {
   const WebComponent = forwardRef<T, HookProps<P>>(({ children, mapping = {}, eventsAreCamelCase = false, ...props }: ChildHookProps<P>, ref) => {
-    const [simpleProps, innerRef] = useWebComponent<T>(props, mapping, eventsAreCamelCase)
+    const { className, class: classProp, ...restProps } = props
+    const [simpleProps, innerRef] = useWebComponent<T>(restProps, mapping, eventsAreCamelCase)
 
-    return <Component {...simpleProps} ref={mergeRefs([innerRef, ref])}>{children}</Component>
+    return <Component {...simpleProps} class={genClassList(className, classProp)} ref={mergeRefs([innerRef, ref])}>{children}</Component>
   })
 
   const displayName = isComponentType(Component) ? Component.displayName : Component

--- a/src/withWebComponent.test.tsx
+++ b/src/withWebComponent.test.tsx
@@ -18,11 +18,18 @@ describe('withWebComponent', () => {
   it('can pass an html tag name and get a component out thatll pass through all the important standard html props', async () => {
     const FancyInput = withWebComponent('input')
 
+    // this throws an error cause react is not pleased w/ `class` showing up on a standard element
+    // you shouldn't be doing this in the first place tho, so ima just ignore it
+    const origError = console.error
+    console.error = jest.fn()
+
     const { findByTestId } = render(<FancyInput id='testId' className='testClass' data-testid='testTestId' />)
 
     const theInput = await findByTestId('testTestId')
     expect(theInput).toHaveAttribute('id', 'testId')
     expect(theInput).toHaveAttribute('class', 'testClass')
+
+    console.error = origError
   })
 
   it('will correctly wire all the things on an actual web component', async () => {
@@ -73,5 +80,13 @@ describe('withWebComponent', () => {
 
     expect(onButtonClicked.mock.calls[0][0].type).toBe('button-clicked')
     expect(onButtonClicked.mock.calls[0][0].detail).toStrictEqual({ attributeValue: 'ref test' })
+  })
+
+  it('will pass anything sent in on `className` to the `class` prop since react wont process className for you here', async () => {
+    const { findByTestId } = render(<TestComponent className='this should show' class='up on class' data-testid='testComponent' />)
+
+    const theElement = await findByTestId('testComponent')
+
+    expect(theElement).toHaveAttribute('class', 'this should show up on class')
   })
 })


### PR DESCRIPTION
## Great Job! What'd you change?
- styled-components (and probably other style libs) use `className` and cannot be configured to do otherwise
- react doesn't transform `className` on web-components for whatever reason
- so catch it (and any potential `class` prop) and merge them into `class` on the rendered component

## Checklist
- [x] tested locally
- [x] added new dependencies
- [x] updated the docs
- [x] added a test

